### PR TITLE
Fix bug with part_data_end and body_end not emitted

### DIFF
--- a/src/multipart_parser.c
+++ b/src/multipart_parser.c
@@ -241,7 +241,7 @@ size_t multipart_parser_execute(multipart_parser* p, const char *buf, size_t len
       /* fallthrough */
       case s_part_data:
         multipart_log("s_part_data");
-        if (c == CR && i >= len - p->boundary_length - 6) {
+        if (c == CR) {
             EMIT_DATA_CB(part_data, buf + mark, i - mark);
             mark = i;
             p->state = s_part_data_almost_boundary;


### PR DESCRIPTION
At least for a small text file containing just "This is a test."